### PR TITLE
Native.xs: add SOCK_CLOEXEC to sockets

### DIFF
--- a/Native.xs
+++ b/Native.xs
@@ -421,7 +421,7 @@ _getaddrinfo(Net_DNS_Native *self, char *host, SV* sv_service, SV* sv_hints, int
             DNS_reinit_pool(self);
         }
 #endif
-        if (socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, fd) != 0)
+        if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, PF_UNSPEC, fd) != 0)
             croak("socketpair(): %s", strerror(errno));
         
         char *service = SvOK(sv_service) ? SvPV_nolen(sv_service) : "";


### PR DESCRIPTION
hello,

i ran into some problems using Net::DNS::Native and mojo with stuff that would fork+exec as a means of reload. i don't have a short reproducer handy, but every fork+exec would leave open and leak all the socket handles from the previous process. adding cloexec here solves the problem for me, and i believe is the right thing to do anyway.