### PR TITLE
Native.xs: apply SOCK_CLOEXEC to Linux only

### DIFF
--- a/Native.xs
+++ b/Native.xs
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <semaphore.h>
 #include <stdint.h>
+#include <fcntl.h>
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
@@ -427,7 +428,10 @@ _getaddrinfo(Net_DNS_Native *self, char *host, SV* sv_service, SV* sv_hints, int
         if (socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, fd) != 0)
 #endif
             croak("socketpair(): %s", strerror(errno));
-        
+#ifndef __linux__
+        fcntl(fd, F_SETFD, FD_CLOEXEC);
+#endif
+
         char *service = SvOK(sv_service) ? SvPV_nolen(sv_service) : "";
         struct addrinfo *hints = NULL;
         

--- a/Native.xs
+++ b/Native.xs
@@ -425,7 +425,8 @@ _getaddrinfo(Net_DNS_Native *self, char *host, SV* sv_service, SV* sv_hints, int
         if (socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, fd) != 0)
             croak("socketpair(): %s", strerror(errno));
 
-        fcntl(fd, F_SETFD, FD_CLOEXEC);
+        fcntl(fd[0], F_SETFD, FD_CLOEXEC);
+        fcntl(fd[1], F_SETFD, FD_CLOEXEC);
 
         char *service = SvOK(sv_service) ? SvPV_nolen(sv_service) : "";
         struct addrinfo *hints = NULL;

--- a/Native.xs
+++ b/Native.xs
@@ -422,15 +422,10 @@ _getaddrinfo(Net_DNS_Native *self, char *host, SV* sv_service, SV* sv_hints, int
             DNS_reinit_pool(self);
         }
 #endif
-#ifdef __linux__
-        if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, PF_UNSPEC, fd) != 0)
-#else
         if (socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, fd) != 0)
-#endif
             croak("socketpair(): %s", strerror(errno));
-#ifndef __linux__
+
         fcntl(fd, F_SETFD, FD_CLOEXEC);
-#endif
 
         char *service = SvOK(sv_service) ? SvPV_nolen(sv_service) : "";
         struct addrinfo *hints = NULL;

--- a/Native.xs
+++ b/Native.xs
@@ -421,7 +421,11 @@ _getaddrinfo(Net_DNS_Native *self, char *host, SV* sv_service, SV* sv_hints, int
             DNS_reinit_pool(self);
         }
 #endif
+#ifdef __linux__
         if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, PF_UNSPEC, fd) != 0)
+#else
+        if (socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, fd) != 0)
+#endif
             croak("socketpair(): %s", strerror(errno));
         
         char *service = SvOK(sv_service) ? SvPV_nolen(sv_service) : "";


### PR DESCRIPTION
#5 works great on Linux, but introduces a regression on all non-Linux platforms where this module used to previously work, as `SOCK_CLOEXEC` is exclusive to Linux.

This PR fixes the regression by conditionally compiling `SOCK_CLOEXEC`. It looks kludgy, so please let me know if there is a better way.