### PR TITLE
Check for bstree_get rv to avoid segfaults in DESTROY block

### DIFF
--- a/Native.xs
+++ b/Native.xs
@@ -706,7 +706,10 @@ DESTROY(Net_DNS_Native *self)
             
             for (i=0, l=bstree_size(self->fd_map); i<l; i++) {
                 DNS_result *res = bstree_get(self->fd_map, fds[i]);
-                
+                if ( res == NULL ) {
+                    break;
+                }
+
                 if (!res->dequeued) {
                     if (!res->gai_error && res->hostinfo) freeaddrinfo(res->hostinfo);
                     if (res->arg->hints)   free(res->arg->hints);


### PR DESCRIPTION
We've had issues with regular SEGV in the DESTROY block. The patch handles prevents the segmentation faults but does not really tackle the potential underlying issues.